### PR TITLE
Add password reset endpoints

### DIFF
--- a/templates/reset_password.html
+++ b/templates/reset_password.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Réinitialisation du mot de passe</title>
+</head>
+<body>
+    <h2>Réinitialiser le mot de passe</h2>
+    {% if message %}
+        <p style="color: green;">{{ message }}</p>
+    {% endif %}
+    {% if error %}
+        <p style="color: red;">{{ error }}</p>
+    {% endif %}
+    <form method="post">
+        {% csrf_token %}
+        <input type="password" name="password" placeholder="Nouveau mot de passe" required><br>
+        <input type="password" name="password2" placeholder="Confirmer le mot de passe" required><br>
+        <button type="submit">Modifier</button>
+    </form>
+</body>
+</html>

--- a/users/urls.py
+++ b/users/urls.py
@@ -30,5 +30,8 @@ urlpatterns = [
     path("signup-resend-code", views.resend_code_of_signup),
     # profile update
     path("update-profile", views.update_user_profile),
+    # password reset
+    path("request-reset-password", views.request_reset_password),
+    path("reset-password/<str:uidb64>/<str:token>", views.reset_password, name="reset_password"),
 
 ]


### PR DESCRIPTION
## Summary
- add API endpoint to send password reset link to a user by email
- add HTML page and handler to set a new password from the reset link

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a767f4e13c833289e29b35389de327