### PR TITLE
feat(auth): async password reset email

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 bcrypt==3.2.0
 boto3
-# Celery==5.4.0
+Celery==5.4.0
 channels
 daphne
 Django==4.2.4

--- a/solar_backend/__init__.py
+++ b/solar_backend/__init__.py
@@ -1,0 +1,6 @@
+try:  # pragma: no cover - Celery might be absent in tests
+    from .celery import app as celery_app
+    __all__ = ("celery_app",)
+except Exception:  # pragma: no cover
+    celery_app = None
+    __all__ = ()

--- a/solar_backend/celery.py
+++ b/solar_backend/celery.py
@@ -1,0 +1,13 @@
+import os
+from celery import Celery
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'solar_backend.settings')
+
+app = Celery('solar_backend')
+app.config_from_object('django.conf:settings', namespace='CELERY')
+app.autodiscover_tasks()
+
+
+@app.task(bind=True)
+def debug_task(self):  # pragma: no cover
+    print(f'Request: {self.request!r}')

--- a/solar_backend/settings.py
+++ b/solar_backend/settings.py
@@ -14,7 +14,7 @@ load_dotenv()
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = "django-insecure-517me7l6)qts)dk@or&cs*sj-wm38p!8p918&k7g9kktdav#i5"
-DEPLOYMENT = True
+DEPLOYMENT = os.getenv("DEPLOYMENT", "True") == "True"
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -56,6 +56,9 @@ REST_FRAMEWORK = {
         "rest_framework_simplejwt.authentication.JWTAuthentication",
     ],
     "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
+    "DEFAULT_THROTTLE_RATES": {
+        "reset_password": "5/hour",
+    },
 }
 
 # minutes
@@ -215,7 +218,27 @@ EMAIL_HOST_USER = "rakotoarisoa.ga@gmail.com"
 EMAIL_HOST_PASSWORD = "loxb wora pney rane"
 EMAIL_USE_TLS = True
 EMAIL_USE_SSL = False
+EMAIL_TIMEOUT = 5
 
 # time
 TIME_ZONE = 'Indian/Antananarivo'
 USE_TZ = True  # On garde True pour stocker en UTC mais savoir faire les conversions
+
+# Celery configuration
+CELERY_BROKER_URL = os.getenv('CELERY_BROKER_URL', 'redis://localhost:6379/0')
+CELERY_RESULT_BACKEND = os.getenv('CELERY_RESULT_BACKEND', CELERY_BROKER_URL)
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {'class': 'logging.StreamHandler'},
+    },
+    'loggers': {
+        'mail.reset_password': {
+            'handlers': ['console'],
+            'level': 'INFO',
+            'propagate': False,
+        },
+    },
+}

--- a/users/tasks.py
+++ b/users/tasks.py
@@ -1,0 +1,64 @@
+import logging
+import smtplib
+
+try:  # pragma: no cover - fallback if Celery not installed
+    from celery import shared_task
+except Exception:  # pragma: no cover
+    def shared_task(*decorator_args, **decorator_kwargs):
+        def wrapper(func):
+            class DummyTask:
+                def __init__(self, f):
+                    self.f = f
+                    self.request = type('req', (), {'retries': 0})()
+
+                def delay(self, *args, **kwargs):
+                    return self.f(self, *args, **kwargs)
+
+                def retry(self, exc=None, countdown=0):
+                    raise Exception("retry") from exc
+
+                def __call__(self, *args, **kwargs):
+                    return self.f(self, *args, **kwargs)
+
+                def run(self, *args, **kwargs):
+                    return self.f(self, *args, **kwargs)
+
+            return DummyTask(func)
+        return wrapper
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.mail import EmailMultiAlternatives
+
+logger = logging.getLogger('mail.reset_password')
+
+
+@shared_task(bind=True, max_retries=3)
+def send_reset_password_email(self, user_id, reset_link, request_id=None):
+    """Send password reset email asynchronously with retries."""
+    User = get_user_model()
+    user = User.objects.filter(id=user_id).first()
+    extra = {'email': None, 'user_id': user_id, 'request_id': request_id}
+    if not user:
+        logger.warning('user_missing', extra=extra | {'status': 'user_missing'})
+        return
+    extra['email'] = user.email
+    subject = "Réinitialisation de mot de passe"
+    text_body = f"Utilisez ce lien pour réinitialiser votre mot de passe : {reset_link}"
+    html_body = (
+        "Cliquez sur le lien pour réinitialiser votre mot de passe: "
+        f"<a href='{reset_link}'>Réinitialiser</a>"
+    )
+    try:
+        msg = EmailMultiAlternatives(subject, text_body, to=[user.email])
+        msg.attach_alternative(html_body, "text/html")
+        msg.send(timeout=getattr(settings, 'EMAIL_TIMEOUT', 10))
+        logger.info('sent', extra=extra | {'status': 'sent'})
+    except smtplib.SMTPException as exc:
+        logger.warning(
+            'smtp_error', extra=extra | {'status': 'retry', 'err': str(exc)}
+        )
+        raise self.retry(exc=exc, countdown=2 ** self.request.retries)
+    except Exception as exc:  # pragma: no cover
+        logger.error(
+            'unexpected_error', extra=extra | {'status': 'error', 'err': str(exc)}
+        )

--- a/users/tests/test_password_reset.py
+++ b/users/tests/test_password_reset.py
@@ -1,0 +1,68 @@
+import smtplib
+import time
+from django.urls import reverse
+from django.test import TestCase
+from unittest.mock import patch
+from django.utils.http import urlsafe_base64_encode
+from django.utils.encoding import force_bytes
+from django.contrib.auth.tokens import PasswordResetTokenGenerator
+
+from users.models import ProfilUser
+from users.tasks import send_reset_password_email
+
+
+class RequestResetPasswordTests(TestCase):
+    def setUp(self):
+        self.user = ProfilUser.objects.create_user(
+            email='test@example.com',
+            password='password123',
+            first_name='John',
+            last_name='Doe'
+        )
+        self.url = reverse('request_reset_password')
+
+    @patch('users.views.transaction.on_commit', side_effect=lambda fn: fn())
+    @patch('users.views.send_reset_password_email.delay')
+    def test_response_immediate(self, mock_delay, mock_on_commit):
+        mock_delay.side_effect = lambda *args, **kwargs: time.sleep(0.1)
+        start = time.time()
+        response = self.client.post(self.url, {'email': self.user.email})
+        duration = time.time() - start
+        self.assertLess(duration, 0.5)
+        self.assertEqual(response.status_code, 202)
+        mock_delay.assert_called_once()
+
+    @patch('users.views.transaction.on_commit', side_effect=lambda fn: fn())
+    @patch('users.views.send_reset_password_email.delay')
+    def test_user_absent_same_response(self, mock_delay, mock_on_commit):
+        response = self.client.post(self.url, {'email': 'absent@example.com'})
+        self.assertEqual(response.status_code, 202)
+        mock_delay.assert_not_called()
+
+    @patch('users.views.transaction.on_commit', side_effect=lambda fn: fn())
+    @patch('users.views.send_reset_password_email.delay')
+    def test_uid_token_and_link_generated(self, mock_delay, mock_on_commit):
+        response = self.client.post(self.url, {'email': self.user.email})
+        self.assertEqual(response.status_code, 202)
+        user_id, reset_link, request_id = mock_delay.call_args.args
+        self.assertEqual(str(user_id), str(self.user.id))
+        uidb64 = urlsafe_base64_encode(force_bytes(self.user.pk))
+        token = PasswordResetTokenGenerator().make_token(self.user)
+        self.assertIn(uidb64, reset_link)
+        self.assertIn(token, reset_link)
+
+
+class SendResetPasswordEmailTaskTests(TestCase):
+    def setUp(self):
+        self.user = ProfilUser.objects.create_user(
+            email='task@example.com',
+            password='password123',
+            first_name='Task',
+            last_name='User'
+        )
+
+    @patch('users.tasks.logger')
+    @patch('users.tasks.EmailMultiAlternatives.send', side_effect=smtplib.SMTPException('boom'))
+    def test_retry_on_smtp_error(self, mock_send, mock_logger):
+        with self.assertRaises(Exception):
+            send_reset_password_email.run(user_id=self.user.id, reset_link='http://test', request_id='req')

--- a/users/throttles.py
+++ b/users/throttles.py
@@ -1,0 +1,15 @@
+from rest_framework.throttling import SimpleRateThrottle
+
+
+class ResetPasswordRateThrottle(SimpleRateThrottle):
+    scope = 'reset_password'
+
+    def get_cache_key(self, request, view):
+        email = request.data.get('email')
+        ident = self.get_ident(request)
+        if not email:
+            return None
+        return self.cache_format % {
+            'scope': self.scope,
+            'ident': f'{ident}:{email}'
+        }

--- a/users/urls.py
+++ b/users/urls.py
@@ -31,7 +31,7 @@ urlpatterns = [
     # profile update
     path("update-profile", views.update_user_profile),
     # password reset
-    path("request-reset-password", views.request_reset_password),
+    path("request-reset-password", views.RequestResetPasswordView.as_view(), name="request_reset_password"),
     path("reset-password/<str:uidb64>/<str:token>", views.reset_password, name="reset_password"),
 
 ]


### PR DESCRIPTION
## Summary
- make password reset request non-blocking via Celery task with retries and logging
- add rate limiting and structured logging for reset emails
- cover reset flow and task retry with unit tests

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: [Errno -2] Name or service not known)*
- `DEPLOYMENT=False python manage.py test users.tests.test_password_reset -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68ad650a53508332b8eadfa16815fe88