### PR TITLE
feat: add production-ready Docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,19 +1,34 @@
-# Python
-__pycache__/
-*.py[cod]
-*.pyo
-
-# Environments
-.env
-*.env
-
-# Django
-staticfiles/
-media/
-
 # Git
 .git
 .gitignore
 
-# Other
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+*.egg-info
+*.egg
+*.log
+
+# Environments
+.env
+*.env
+.venv/
+venv/
+pip-wheel-metadata/
+
+# Node
+node_modules/
+
+# Django
+staticfiles/
+assets/
+media/
+
+# Database & test artifacts
 db.sqlite3
+pytest_cache/
+.coverage
+htmlcov/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,72 +1,71 @@
-# ---------- STAGE 1: builder ----------
-    FROM python:3.12-slim AS builder
+# syntax=docker/dockerfile:1
 
-    ENV PYTHONDONTWRITEBYTECODE=1 \
-        PYTHONUNBUFFERED=1 \
-        PIP_NO_CACHE_DIR=1
-    
-    # Paquets nécessaires pour compiler Pillow & autres deps natives
-    RUN apt-get update && apt-get install -y --no-install-recommends \
-        build-essential \
-        gcc \
-        libjpeg62-turbo-dev \
-        zlib1g-dev \
-        libpng-dev \
-        libopenjp2-7-dev \
-        libtiff5-dev \
-        libfreetype6-dev \
-        liblcms2-dev \
-        libwebp-dev \
-        && rm -rf /var/lib/apt/lists/*
-    
-    WORKDIR /app
-    
-    # Optimise le cache pip
-    COPY requirements.txt ./
-    
-    # Mets à jour pip/setuptools/wheel puis installe les deps dans /install
-    RUN python -m pip install --upgrade pip setuptools wheel \
-     && pip install --prefix=/install --no-cache-dir -r requirements.txt
-    
-    # ---------- STAGE 2: runtime ----------
-    FROM python:3.12-slim AS runtime
-    
-    ENV PYTHONDONTWRITEBYTECODE=1 \
-        PYTHONUNBUFFERED=1 \
-        PIP_NO_CACHE_DIR=1 \
-        PORT=8000
-    
-    # Libs partagées nécessaires à l'exécution de Pillow (sans toolchain)
-    RUN apt-get update && apt-get install -y --no-install-recommends \
-        libjpeg62-turbo \
-        zlib1g \
-        libpng16-16 \
-        libopenjp2-7 \
-        libtiff5 \
-        libfreetype6 \
-        liblcms2-2 \
-        libwebp7 \
-        tzdata \
-        && rm -rf /var/lib/apt/lists/*
-    
-    # Copie des packages Python construits en builder → runtime
-    # (les wheels installés avec --prefix=/install sont sous /install)
-    COPY --from=builder /install /usr/local
-    
-    # App non-root
-    RUN useradd -m -u 10001 appuser
-    WORKDIR /app
-    USER appuser
-    
-    # Copie du code (ajoute un .dockerignore pour éviter node_modules, .venv, etc.)
-    COPY --chown=appuser:appuser . /app
-    
-    # Expose le port de l’app web (Gunicorn/Django par ex.)
-    EXPOSE 8000
-    
-    # CMD par défaut (adapte si ASGI/uvicorn ou autre)
-    # Exemple WSGI:
-    # CMD ["gunicorn", "project.wsgi:application", "--bind", "0.0.0.0:8000", "--workers", "2"]
-    # Exemple ASGI (si tu as asgi.py):
-    # CMD ["gunicorn", "project.asgi:application", "-k", "uvicorn.workers.UvicornWorker", "--bind", "0.0.0.0:8000", "--workers", "2"]
-    
+##############################
+# Builder image
+FROM python:3.12-slim AS builder
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# build deps for Pillow, psycopg etc.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    gcc \
+    libjpeg62-turbo-dev \
+    zlib1g-dev \
+    libpng-dev \
+    libtiff5-dev \
+    libfreetype6-dev \
+    liblcms2-dev \
+    libwebp-dev \
+    libopenjp2-7-dev \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# install Python deps into /install to leverage layer caching
+COPY requirements.txt ./
+RUN python -m pip install --upgrade pip setuptools wheel \
+    && pip install --prefix=/install -r requirements.txt
+
+##############################
+# Runtime image
+FROM python:3.12-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# runtime libs only
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libjpeg62-turbo \
+    zlib1g \
+    libpng16-16 \
+    libtiff5 \
+    libfreetype6 \
+    liblcms2-2 \
+    libwebp7 \
+    libopenjp2-7 \
+    libpq5 \
+    tzdata \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# copy installed packages from builder
+COPY --from=builder /install /usr/local
+
+# non-root user
+RUN useradd -m -u 10001 appuser
+WORKDIR /app
+USER appuser
+
+COPY --chown=appuser:appuser . /app
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:${PORT:-8000}/health/ || exit 1
+
+CMD ["sh", "-c", "gunicorn solar_backend.asgi:application -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:${PORT:-8000} --workers ${WEB_CONCURRENCY:-2}"]
+# For WSGI replace the command with:
+# CMD ["sh", "-c", "gunicorn solar_backend.wsgi:application --bind 0.0.0.0:${PORT:-8000} --workers ${WEB_CONCURRENCY:-2}"]


### PR DESCRIPTION
## Summary
- replace placeholder Dockerfile with multi-stage production build
- tighten `.dockerignore` to keep builds lean

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: SyntaxError in add_swagger_decorators.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ad90d7b6ec8332af2c0ee01f949f37