### PR TITLE
Use entrypoint for Django startup tasks in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,5 +78,8 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
     CMD curl -fsS "http://localhost:${PORT}/health/" || exit 1
 
+# Script d'initialisation : collecte des statiques et migrations
+ENTRYPOINT ["/app/entrypoint.sh"]
 
-CMD ["sh", "-c", "gunicorn solar_backend.wsgi:application --bind 0.0.0.0:${PORT} --workers ${WEB_CONCURRENCY:-2}"]
+# Lancement de Gunicorn avec prise en compte des variables d'environnement
+CMD ["bash", "-c", "gunicorn solar_backend.wsgi:application --bind 0.0.0.0:${PORT} --workers ${WEB_CONCURRENCY:-2}"]


### PR DESCRIPTION
## Summary
- run startup collectstatic/migrations via entrypoint
- launch gunicorn with bash to expand PORT and WEB_CONCURRENCY

## Testing
- `python -m pytest` *(fails: django.db.utils.OperationalError: [Errno -2] Name or service not known)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9aa78d28833282b48ea8e00251f6