### PR TITLE
Allow STATIC_ROOT override via environment

### DIFF
--- a/solar_backend/settings.py
+++ b/solar_backend/settings.py
@@ -161,7 +161,11 @@ USE_I18N = True
 # https://docs.djangoproject.com/en/4.2/howto/static-files/
 
 STATIC_URL = "static/"
-STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
+# Allow overriding the static files destination via the ``STATIC_ROOT``
+# environment variable. This is useful in restricted environments where the
+# default location may not be writable (e.g. during collectstatic on read-only
+# filesystems).
+STATIC_ROOT = os.getenv("STATIC_ROOT", os.path.join(BASE_DIR, "staticfiles"))
 MEDIA_URL = "/media/"
 MEDIA_ROOT = os.path.join(BASE_DIR, "assets")
 # Default primary key field type


### PR DESCRIPTION
## Summary
- allow setting STATIC_ROOT via environment variable to avoid permission errors during collectstatic

## Testing
- `STATIC_ROOT=/tmp/staticfiles python manage.py collectstatic --noinput`
- `python manage.py test` *(fails: ImportError: 'tests' module incorrectly imported from '/workspace/solar-backend/users/tests')*


------
https://chatgpt.com/codex/tasks/task_e_68aea3089a4083329ddf18aadf559efd