### PR TITLE
Fallback static root to temp directory when unwritable

### DIFF
--- a/solar_backend/settings.py
+++ b/solar_backend/settings.py
@@ -1,5 +1,6 @@
 import os
 import ast
+import tempfile
 from pathlib import Path
 from datetime import timedelta
 
@@ -166,6 +167,8 @@ STATIC_URL = "static/"
 # default location may not be writable (e.g. during collectstatic on read-only
 # filesystems).
 STATIC_ROOT = os.getenv("STATIC_ROOT", os.path.join(BASE_DIR, "staticfiles"))
+if not os.access(os.path.dirname(STATIC_ROOT), os.W_OK):
+    STATIC_ROOT = os.path.join(tempfile.gettempdir(), "staticfiles")
 MEDIA_URL = "/media/"
 MEDIA_ROOT = os.path.join(BASE_DIR, "assets")
 # Default primary key field type


### PR DESCRIPTION
## Summary
- fallback STATIC_ROOT to a temporary directory when the default location cannot be written

## Testing
- `python manage.py collectstatic --noinput`
- `python -m pytest` (fails: [Errno -2] Name or service not known)


------
https://chatgpt.com/codex/tasks/task_e_68aea5eec8208332878aa1e164d59036