### PR TITLE
Add root logging and debugging note

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Ce projet est le backend d’une plateforme de gestion et de suivi de systèmes 
    python manage.py runserver
    ```
 
+## 🐛 Débogage
+
+Pour voir les erreurs détaillées en local, lance le serveur avec la commande ci-dessus. Les logs sont maintenant affichés dans la console pour toutes les erreurs Django. Si une variable `DATABASE_URL` non valide est définie dans `.env`, Django essaiera de se connecter à cette base de données et échouera. Supprime ou commente cette variable pour utiliser la base SQLite par défaut `db.sqlite3`.
+
 ---
 
 ## 🔐 Variables d’environnement

--- a/solar_backend/settings.py
+++ b/solar_backend/settings.py
@@ -223,7 +223,15 @@ LOGGING = {
     'handlers': {
         'console': {'class': 'logging.StreamHandler'},
     },
+    'root': {
+        'handlers': ['console'],
+        'level': 'INFO',
+    },
     'loggers': {
+        'django': {
+            'handlers': ['console'],
+            'level': 'INFO',
+        },
         'mail.reset_password': {
             'handlers': ['console'],
             'level': 'INFO',


### PR DESCRIPTION
## Summary
- ensure all Django logs output to console
- document how to see detailed errors and use SQLite when DATABASE_URL is invalid

## Testing
- `PYTHONDONTWRITEBYTECODE=1 DATABASE_URL='' python test_api.py` *(fails: no such column: users_profiluser.is_verified)*
- `PYTHONDONTWRITEBYTECODE=1 DATABASE_URL='' python test_swagger.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb98e19cc83328b3b6d5bfea00b3e