### PR TITLE
Use Uvicorn with health endpoint and defaults for Railway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,85 +1,27 @@
-# syntax=docker/dockerfile:1
-
-##############################
-# Builder image
-FROM python:3.12-slim-bookworm AS builder
-
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1 \
-    PIP_NO_CACHE_DIR=1 \
-    DEBIAN_FRONTEND=noninteractive
-
-ARG APT_FLAGS="--no-install-recommends"
-
-# Dependence de build pour Pillow, psych, etc.
-RUN apt-get update \
-    && apt-get install -y $APT_FLAGS \
-    build-essential \
-    gcc \
-    libjpeg62-turbo-dev \
-    zlib1g-dev \
-    libpng-dev \
-    libtiff-dev \
-    libfreetype6-dev \
-    liblcms2-dev \
-    libwebp-dev \
-    libopenjp2-7-dev \
-    libpq-dev \
-    && rm -rf /var/lib/apt/lists/*
+FROM python:3.10
 
 WORKDIR /app
 
-COPY requirements.txt ./
-
-RUN python -m pip install --upgrade pip setuptools wheel \
-    && pip install --prefix=/install -r requirements.txt
-
-##############################
-# Runtime image
-FROM python:3.12-slim-bookworm AS runtime
-
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1 \
-    PIP_NO_CACHE_DIR=1 \
-    DEBIAN_FRONTEND=noninteractive \
-    TZ=UTC \
-    PORT=8000
-
-ARG APT_FLAGS="--no-install-recommends"
-
 RUN apt-get update \
-    && apt-get install -y $APT_FLAGS \
-    libjpeg62-turbo \
-    zlib1g \
-    libpng16-16 \
-    libtiff6 \
-    libfreetype6 \
-    liblcms2-2 \
-    libwebp7 \
-    libopenjp2-7 \
-    libpq5 \
-    tzdata \
-    curl \
+    && apt-get install -y --no-install-recommends git libpq-dev ffmpeg curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Copier les packages Python préinstallés (depuis le builder)
-COPY --from=builder /install /usr/local
+RUN pip install --upgrade pip
 
-# Utilisateur non-root
-RUN useradd -m -u 10001 appuser
-WORKDIR /app
-USER appuser
+COPY requirements.txt /app/
+RUN pip install -r requirements.txt
 
-# Copier le code de l'app
-COPY --chown=appuser:appuser . /app
+COPY . /app/
+
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 EXPOSE 8000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD curl -fsS "http://localhost:${PORT}/health/" || exit 1
+    CMD curl -fsS "http://0.0.0.0:${PORT:-8000}/health/" || exit 1
 
-# Script d'initialisation : collecte des statiques et migrations
-ENTRYPOINT ["bash", "docker/entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]
 
-# Lancement de Gunicorn (ASGI) avec gestion des variables d'environnement
-CMD ["bash", "-c", "gunicorn solar_backend.asgi:application -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:${PORT} --workers ${WEB_CONCURRENCY:-2} --timeout ${WEB_TIMEOUT:-60} --graceful-timeout 30 --keep-alive 5"]
+CMD ["sh", "-c", "uvicorn solar_backend.asgi:application --host 0.0.0.0 --port ${PORT:-8000} --proxy-headers --forwarded-allow-ips='*' --timeout-keep-alive 5"]
+

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,30 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
-# Determine port (default 8000) using Python so shell ${PORT} isn't required
-export PORT=$(python - <<'PY'
-import os
-print(os.getenv("PORT", "8000"))
-PY
-)
-
-# Wait briefly for Postgres if DATABASE_URL points to it
-if [ -n "${DATABASE_URL:-}" ] && [[ "${DATABASE_URL}" == postgres* ]]; then
-  python <<'PY'
-import os, time
-url = os.environ["DATABASE_URL"]
-for _ in range(5):
-    try:
-        import psycopg
-        with psycopg.connect(url, connect_timeout=2) as conn:
-            conn.execute("SELECT 1")
-        break
-    except Exception:
-        time.sleep(1)
-PY
-fi
-
-python manage.py collectstatic --noinput || true
-python manage.py migrate || true
+# Run Django management tasks without blocking startup
+python manage.py collectstatic --noinput || true &
+python manage.py migrate || true &
 
 exec "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,5 @@ python-dotenv==1.0.0
 # Routes==2.5.1
 
 # Production server and database utilities
-gunicorn
 uvicorn[standard]
 dj-database-url

--- a/solar_backend/urls.py
+++ b/solar_backend/urls.py
@@ -2,10 +2,10 @@ from django.conf.urls.static import static
 from django.urls import include, path
 from django.conf import settings
 from django.contrib import admin
+from django.http import HttpResponse
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
 from rest_framework import permissions
-from .health import health_view, readiness
 
 schema_view = get_schema_view(
    openapi.Info(
@@ -21,6 +21,11 @@ schema_view = get_schema_view(
 )
 
 
+# Lightweight health check that avoids touching the database
+def health_view(request):
+    return HttpResponse("ok")
+
+
 urlpatterns = [
     path('swagger<format>/', schema_view.without_ui(cache_timeout=0), name='schema-json'),
     path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
@@ -28,7 +33,6 @@ urlpatterns = [
     #
     path('admin/', admin.site.urls),
     path('health/', health_view, name='health'),
-    path('readiness/', readiness, name='readiness'),
     path('api/solar/users/', include("users.urls")),
     path('api/solar/modules/', include("module.urls")),
     path('api/solar/rating/', include("rating.urls")),


### PR DESCRIPTION
## Summary
- add lightweight `/health` view
- hard-code safe defaults for env-less Railway deploy
- replace gunicorn Docker setup with simple Uvicorn image and healthcheck

## Testing
- `python manage.py test` *(fails: ImportError: 'tests' module incorrectly imported)*

------
https://chatgpt.com/codex/tasks/task_e_68afdd902dcc833285e41c623693b186