### PR TITLE
Fix websocket consumer import path

### DIFF
--- a/graphique/routing.py
+++ b/graphique/routing.py
@@ -1,6 +1,6 @@
 # realtime/routing.py
 from django.urls import re_path
-from consumers import ModuleDataConsumer
+from .consumers import ModuleDataConsumer
 
 websocket_urlpatterns = [
 


### PR DESCRIPTION
## Summary
- use a relative import for ModuleDataConsumer in graphique routing to resolve the ModuleNotFoundError during ASGI startup

## Testing
- python manage.py check


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69318cb65c7c832bb7d0b0848424279d)